### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/leptos_three/Cargo.toml
+++ b/leptos_three/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 description = "A Leptos library for Three.js"
 license = "MIT"
+repository = "https://github.com/richardanaya/leptos_three"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow crates.io, rust-digger, and others link to it